### PR TITLE
add requestee method to get the requested user instance

### DIFF
--- a/request-model/common/request-model.js
+++ b/request-model/common/request-model.js
@@ -9,7 +9,7 @@ Request = BaseModel.extend();
  * Get the User instance for the user who made the request
  * @returns {User} The user who made the request
  */
-Request.prototype.user = function () {
+Request.prototype.requester = function () {
     return Meteor.users.findOne(this.requesterId);
 };
 
@@ -17,7 +17,7 @@ Request.prototype.user = function () {
  * Get the User instance for the user who received the request
  * @returns {User} The user who received the request
  */
-Request.prototype.requestee = function() {
+Request.prototype.user = function() {
     return Meteor.users.findOne(this.userId);
 };
 

--- a/request-model/common/request-model.js
+++ b/request-model/common/request-model.js
@@ -14,6 +14,14 @@ Request.prototype.user = function () {
 };
 
 /**
+ * Get the User instance for the user who received the request
+ * @returns {User} The user who received the request
+ */
+Request.prototype.requestee = function() {
+    return Meteor.users.findOne(this.userId);
+};
+
+/**
  * Accept the friend request
  * @method approve
  */


### PR DESCRIPTION
In the same way that the user method was added to the request to fetch the 'requester', this adds the ability to fetch the user instance of the user receiving the request.
I added this to retrieve user details which could then be displayed in templates (for pending / outgoing friend requests list). I guess it may have made sense to call the original 'user' method 'requester' and this 'requestee' method 'user' to keep it consistent with the keys that are stored in the request collection documents..
