### PR TITLE
Removed named function in publishes

### DIFF
--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@
 Package.describe({
     name: 'socialize:friendships',
     summary: 'A social friendship package',
-    version: '1.1.0',
+    version: '1.1.1',
     git: 'https://github.com/copleykj/socialize-friendships.git',
 });
 

--- a/server/publications.js
+++ b/server/publications.js
@@ -11,7 +11,7 @@ const optionsArgumentCheck = {
     sort: Match.Optional(Object),
 };
 
-publishComposite('socialize.friends', function publishFriends(userId, options = { limit: 20, sort: { createdAt: -1 } }) {
+publishComposite('socialize.friends', function(userId, options = { limit: 20, sort: { createdAt: -1 } }) {
     check(userId, String);
     check(options, optionsArgumentCheck);
     if (!this.userId) {
@@ -37,7 +37,7 @@ publishComposite('socialize.friends', function publishFriends(userId, options = 
     return undefined;
 });
 
-publishComposite('socialize.friendRequests', function publishFriends(options = { limit: 10, sort: { createdAt: -1 } }) {
+publishComposite('socialize.friendRequests', function(options = { limit: 10, sort: { createdAt: -1 } }) {
     check(options, optionsArgumentCheck);
     if (!this.userId) {
         return this.ready();
@@ -59,7 +59,7 @@ publishComposite('socialize.friendRequests', function publishFriends(options = {
     };
 });
 
-publishComposite('socialize.pendingFriendRequests', function publishFriends(options = { limit: 10, sort: { createdAt: -1 } }) {
+publishComposite('socialize.pendingFriendRequests', function(options = { limit: 10, sort: { createdAt: -1 } }) {
     check(options, optionsArgumentCheck);
     if (!this.userId) {
         return this.ready();


### PR DESCRIPTION
Named functions in publish would not return anything.

Running Meteor 1.8.1-beta.15

I have also encountered this issue in user blocking and suspect that this will be everywhere where this style was used. Will fix as I encounter them during rewrite of my app.